### PR TITLE
feat: Create tour and show all author's tours

### DIFF
--- a/Explorer/src/app/feature-modules/tour-authoring/tour-form/tour-form.component.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/tour-form/tour-form.component.ts
@@ -3,6 +3,7 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Tour } from '../model/tour.model';
 import { TourAuthoringService } from '../tour-authoring.service';
 import { Router } from '@angular/router';
+import { AuthService } from 'src/app/infrastructure/auth/auth.service';
 
 @Component({
   selector: 'xp-tour-form',
@@ -15,7 +16,7 @@ export class TourFormComponent implements OnChanges {
   @Input() tour: Tour;
   @Input() shouldEdit: boolean = false;
 
-  constructor(private service: TourAuthoringService, private router: Router) {
+  constructor(private service: TourAuthoringService, private authService: AuthService, private router: Router) {
 }
 
   ngOnChanges(): void {
@@ -34,14 +35,17 @@ export class TourFormComponent implements OnChanges {
   });
 
   addTour(): void {
-    const tour: Tour = {
-      name: this.tourForm.value.name || "",
-      description: this.tourForm.value.description || "",
-      difficulty: Number(this.tourForm.value.difficulty) || 0, 
-      tags: this.tourForm.value.tags || "",
-      status: 0,
-      price: this.tourForm.value.price || 0
-    };
+    const loggedInUser = this.authService.user$.value; 
+  const tour: Tour = {
+    name: this.tourForm.value.name || "",
+    description: this.tourForm.value.description || "",
+    difficulty: Number(this.tourForm.value.difficulty) || 0,
+    tags: this.tourForm.value.tags || "",
+    status: 0,
+    price: this.tourForm.value.price || 0,
+    authorId: loggedInUser.id || 0
+  };
+
   
     console.log('Tour to be added:', tour); 
   

--- a/Explorer/src/app/feature-modules/tour-authoring/tour/tour.component.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/tour/tour.component.ts
@@ -3,6 +3,7 @@ import { TourAuthoringService } from '../tour-authoring.service';
 import { Tour } from '../model/tour.model';
 import { PagedResults } from 'src/app/shared/model/paged-results.model';
 import { Router } from '@angular/router';
+import { AuthService } from 'src/app/infrastructure/auth/auth.service';
 
 @Component({
   selector: 'xp-tour',
@@ -16,20 +17,22 @@ export class TourComponent implements OnInit {
   shouldRenderTourForm: boolean = false;
   shouldEdit: boolean = false;
   
-  constructor(private service: TourAuthoringService, private router: Router) { }
+  constructor(private service: TourAuthoringService, private router: Router, private authService: AuthService) { }
 
   ngOnInit(): void {
     this.getTours();
   }
   
   getTours(): void {
-    this.service.getTours().subscribe({
-      next: (result: PagedResults<Tour>) => {
-        this.tours = result.results;
-      },
-      error: () => {
-      }
-    })
+    this.authService.user$.subscribe((loggedInUser) => {
+      this.service.getTours().subscribe({
+        next: (result: PagedResults<Tour>) => {
+          this.tours = result.results.filter(tour => tour.authorId === loggedInUser.id);
+        },
+        error: () => {
+        }
+      });
+    });
   }
 
   getDifficultyLabel(difficulty: number): string {


### PR DESCRIPTION
##Change goal
As an author,
I want to create a tour
So that I can effectively showcase my tour offerings and ensure they are presented in the most appealing way to potential customers.
Acceptance Criteria:
The author can create a tour by specifying its name, description, difficulty level, and tags.
Each tour initially has a status of "draft" and a default price of 0.
The author can view all created tours.
##UI changes
![Screenshot 2024-10-15 200328](https://github.com/user-attachments/assets/4031540b-3c8c-466d-9b53-821b92ad6abf)
![Screenshot 2024-10-15 200540](https://github.com/user-attachments/assets/dc9675cf-42a8-4b2e-a359-8b0ddc273e5d)
