### PR TITLE
New wallet input, removed wallet button for non-tourists

### DIFF
--- a/Explorer/src/app/feature-modules/administration/account/account.component.css
+++ b/Explorer/src/app/feature-modules/administration/account/account.component.css
@@ -151,3 +151,38 @@
 .save-button:hover {
     background-color: #2ecc71;
 }
+
+
+.balance-input {
+  width: 65px; /* Adjust width as per your UI needs */
+  padding: 5px;
+  font-size: 16px;
+  border: 1px solid #ccc; /* Light border for visibility */
+  border-radius: 4px; /* Rounded corners */
+  text-align: center; /* Center the text inside the input */
+  margin: 5px 0; /* Add some spacing around the input */
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1); /* Subtle inner shadow for depth */
+}
+
+.balance-input:focus {
+  outline: none; /* Remove default blue outline on focus */
+  border-color: #1976d2; /* Highlighted border color */
+  box-shadow: 0 0 5px rgba(25, 118, 210, 0.5); /* Subtle outer glow for focus */
+}
+
+.balance-input::placeholder {
+  color: #aaa; /* Light gray color for the placeholder text */
+  font-style: italic;
+}
+
+.balance-input {
+  -moz-appearance: textfield; /* For Firefox */
+  -webkit-appearance: none; /* For Chrome, Safari, and Edge */
+  appearance: none; /* Standardized property */
+}
+
+.balance-input::-webkit-inner-spin-button, 
+.balance-input::-webkit-outer-spin-button {
+  -webkit-appearance: none; /* Disable the spin buttons */
+  margin: 0; /* Remove margin for better alignment */
+}

--- a/Explorer/src/app/feature-modules/administration/account/account.component.html
+++ b/Explorer/src/app/feature-modules/administration/account/account.component.html
@@ -20,7 +20,7 @@
                     </div>
                     <div class="card-actions">
                         <div class="icon-item">
-                            <button color="primary" (click)="showWallet(acc.id ?? 0)" type="submit" mat-icon-button matTooltip="Show wallet">
+                            <button *ngIf="acc.role === 'Tourist'" color="primary" (click)="showWallet(acc.id ?? 0)" type="submit" mat-icon-button matTooltip="Show wallet">
                                 <img src="assets/icons/wallet.png" alt="Wallet Icon"/>
                             </button>
                             <span class="status-text" style="color: black;" *ngIf="isBlocked(acc)">Blocked</span>
@@ -39,10 +39,19 @@
         </div>
     </div>
     <div *ngIf="showWalletPopup" class="wallet-popup">
-        <div class="popup-content">
+        <div *ngIf="selectedWallet" class="popup-content">
             <h2>Manage Wallet</h2>
             <p><strong>Tourist ID:</strong> {{ selectedWallet?.touristId }}</p>
-            <p><strong>Balance:</strong> {{ selectedWallet?.balance }}</p>
+            <p>
+                <strong>Balance:</strong> </p>
+                <input 
+                    type="number" 
+                    [(ngModel)]="selectedWallet.balance"
+                    (blur)="ensureNonEmptyBalance()"  
+                    placeholder="Enter" 
+                    class="balance-input"
+                />
+            
             <div>
                 <button color="primary" (click)="decreaseBalance()" mat-icon-button matTooltip="Reduce">
                     <img src="assets/icons/reduce.png" alt="Reduce Icon"/>

--- a/Explorer/src/app/feature-modules/administration/account/account.component.ts
+++ b/Explorer/src/app/feature-modules/administration/account/account.component.ts
@@ -145,4 +145,11 @@ export class AccountComponent implements OnInit {
       });
     }
   }
+
+  ensureNonEmptyBalance(): void {
+    if (this.selectedWallet && (this.selectedWallet.balance === null || this.selectedWallet.balance === undefined)) {
+      this.selectedWallet.balance = 0; // Reset to 0 if empty
+    }
+  }
+  
 }

--- a/Explorer/src/app/feature-modules/administration/administration.module.ts
+++ b/Explorer/src/app/feature-modules/administration/administration.module.ts
@@ -11,6 +11,7 @@ import { EncounterFormComponent } from './encounter-form/encounter-form.componen
 import { SharedModule } from "../../shared/shared.module";
 import { MatCardModule } from '@angular/material/card';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -27,7 +28,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     SharedModule,
     MatProgressSpinnerModule,
     MatCardModule,
-    MatTooltipModule
+    MatTooltipModule,
+    FormsModule
 ],
     
  


### PR DESCRIPTION
## Changes
- Added input field option for wallet managing, besides plus-minus buttons
- Removed wallet buttons for non-tourist users in admin account review page
- When number in input field is deleted, it turns to 0 

![image](https://github.com/user-attachments/assets/2ce306e3-fce9-4006-87e7-bcc0dffec20a)
![image](https://github.com/user-attachments/assets/a6d977e0-ac1a-4a59-ac3a-5ab97572076d)

