### PR TITLE
Add Google Analytics tracking with gtag.js

### DIFF
--- a/Explorer/src/app/app.component.ts
+++ b/Explorer/src/app/app.component.ts
@@ -6,14 +6,21 @@ import { NotificationComponent } from './shared/notification/notification.compon
 import { NotificationService } from './shared/notification.service';
 import { NotificationType } from './shared/model/notificationType.enum';
 import { Notification } from './feature-modules/layout/model/notification.model';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs/operators';
+
+
+declare let gtag: Function;
+
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css', '../styles.css']
+  styleUrls: ['./app.component.css', '../styles.css'],
 })
 export class AppComponent implements OnInit {
-  @ViewChild(NotificationComponent) notificationComponent!: NotificationComponent;
+  @ViewChild(NotificationComponent)
+  notificationComponent!: NotificationComponent;
   title = 'Explorer';
   notifications: any[] = [];
   showNotification = false;
@@ -22,8 +29,19 @@ export class AppComponent implements OnInit {
     private authService: AuthService,
     private webSocketService: WebSocketService,
     private notificationService: NotificationService,
-    private cdr: ChangeDetectorRef
-  ) { }
+    private cdr: ChangeDetectorRef,
+    private router: Router
+  ) {
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe((event) => {
+        if (event instanceof NavigationEnd) {
+          gtag('config', 'G-TE49FF5RFZ', {
+            page_path: event.urlAfterRedirects,
+          });
+        }
+      });
+  }
 
   ngAfterViewInit() {
     this.notificationService.register(this.notificationComponent);
@@ -58,7 +76,12 @@ export class AppComponent implements OnInit {
     this.notifications.push(notification);
     this.showNotification = true;
     this.cdr.detectChanges();
-    this.notificationService.notify({ message: notification.Content, duration: 5000, notificationType: NotificationType.MESSAGE, messageSender: 'Explorer' });
+    this.notificationService.notify({
+      message: notification.Content,
+      duration: 5000,
+      notificationType: NotificationType.MESSAGE,
+      messageSender: 'Explorer',
+    });
   }
 
   showedAllNotifications(text: any) {

--- a/Explorer/src/index.html
+++ b/Explorer/src/index.html
@@ -9,6 +9,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TE49FF5RFZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-TE49FF5RFZ');
+  </script>
+
 </head>
 <body class="mat-typography">
   <app-root></app-root>


### PR DESCRIPTION
Integrated Google Analytics by adding gtag.js script to index.html and updating app.component.ts to track page navigation events using Angular Router. This enables page view tracking for analytics purposes.